### PR TITLE
refactor Mslogs class to support custom WordPress table prefix

### DIFF
--- a/includes/ms_log.php
+++ b/includes/ms_log.php
@@ -5,18 +5,19 @@ namespace MoneySpace;
 class Mslogs
 {
 
-
-    public $table_name = 'ms_logs';
-
+    public $table_name;
 
     public function __construct()
     {
 
         global $wpdb;
+        $this->table_name = $wpdb->prefix . 'ms_logs';
 
-        if ($wpdb->get_var("SHOW TABLES LIKE '$this->table_name'") != $this->table_name) {
+        $table_check = $wpdb->get_var("SHOW TABLES LIKE '{$this->table_name}'");
+
+        if ($table_check !== $this->table_name) {
             $charset_collate = $wpdb->get_charset_collate();
-            $sql = "CREATE TABLE $this->table_name (
+            $sql = "CREATE TABLE {$this->table_name} (
                  id mediumint(9) NOT NULL AUTO_INCREMENT,
                  response text NOT NULL,
                  m_func_type text NOT NULL,
@@ -41,30 +42,22 @@ class Mslogs
             'm_datetime' => $m_datetime,
             'm_other' => $m_other
         );
-        $format = array('%s', '%d');
+        $format = array('%s', '%s', '%s', '%s', '%s');
         $wpdb->insert($table, $data, $format);
-        $my_id = $wpdb->insert_id;
-        return $my_id;
+        return $wpdb->insert_id;
     }
 
     public function get()
     {
-        global $wpdb;
-
-        $result = $wpdb->get_results ("SELECT * FROM  $this->table_name");
-
-        return $result;
-
+      global $wpdb;
+      return $wpdb->get_results("SELECT * FROM {$this->table_name}");
     }
 
     public function getType($m_func_type)
     {
-        global $wpdb;
-
-        $result = $wpdb->get_results ("SELECT * FROM  $this->table_name WHERE m_func_type = ".$m_func_type);
-
-        return $result;
-
+      global $wpdb;
+      return $wpdb->get_results(
+          $wpdb->prepare("SELECT * FROM {$this->table_name} WHERE m_func_type = %s", $m_func_type)
+      );
     }
 }
-

--- a/payment-gateway/class-woocommerce-moneyspace-payment-gateway.php
+++ b/payment-gateway/class-woocommerce-moneyspace-payment-gateway.php
@@ -45,7 +45,8 @@ class MNS_Payment_Gateway extends WC_Payment_Gateway
                 'timeout' => 120,
                 'body' => $ms_body
             ));
-            
+            (new Mslogs())->insert($response["body"], 1, 'Create Transaction Card', date("Y-m-d H:i:s"), json_encode($ms_body));
+
             if (is_wp_error($response)) {
                 wc_add_notice(__("Error : " . MNS_NOTICE_ERROR_SETUP, $this->domain), 'error');
                 return;


### PR DESCRIPTION
The Mslogs class functions fail if the WordPress installation uses a custom table prefix.
This should solve the issues, I modified and tested the code on our instance with custom table prefix and it works.